### PR TITLE
Fix the description for app.plugins.loadManifest

### DIFF
--- a/obsidian-ex.d.ts
+++ b/obsidian-ex.d.ts
@@ -1094,9 +1094,9 @@ interface Plugins {
 	 */
 	isEnabled: () => boolean;
 	/**
-	 * Load a specific plugin's manifest by its ID
+	 * Load a specific plugin's manifest by its folder path
 	 */
-	loadManifest: (id: string) => Promise<void>;
+	loadManifest: (path: string) => Promise<void>;
 	/**
 	 * @internal Load all plugin manifests from plugin folder
 	 */


### PR DESCRIPTION
Thank you for this work. I noticed `Plugins.loadManifest` takes the path to a plugin folder, not a plugin id.