### PR TITLE
[FIX] PluginManifest difference to obsidian

### DIFF
--- a/obsidian-ex.d.ts
+++ b/obsidian-ex.d.ts
@@ -1078,7 +1078,7 @@ interface PluginManifest {
     /**
      * Storage location of the plugin relative to the vault root
      */
-    dir: string;
+    dir?: string;
     /**
      * URL for funding the author
      */
@@ -1090,7 +1090,7 @@ interface PluginManifest {
     /**
      * Whether the plugin is designed for desktop use only
      */
-    isDesktopOnly: boolean;
+    isDesktopOnly?: boolean;
     /**
      * Minimum Obsidian version compatible with the plugin
      */


### PR DESCRIPTION
Changed PluginManifest.dir and PluginManifest.isDesktopOnly to be optional like in obsidian.

Fixes #36 