### PR TITLE
Export PropertyWidgetType + Allow arbitrary strings in the type while retaining autocomlete

### DIFF
--- a/obsidian-ex.d.ts
+++ b/obsidian-ex.d.ts
@@ -1341,14 +1341,16 @@ interface PropertyWidget {
     validate(value: unknown): boolean;
 }
 
-type PropertyWidgetType = 'aliases'
+export type PropertyWidgetType = 
+    | 'aliases'
     | 'checkbox'
     | 'date'
     | 'datetime'
     | 'multitext'
     | 'number'
     | 'tags'
-    | 'text';
+    | 'text'
+    | (string & {})
 
 interface ReadViewRenderer {
     addBottomPadding: boolean;


### PR DESCRIPTION
I would find it useful to import the `PropertyWidgetType`, so I've simply exported it in place.
It's also my understanding that custom values are allowed by Obsidian, so I've extended the type with arbitrary strings, while retaining autocomplete for the developer using the type: https://stackoverflow.com/questions/74467392/autocomplete-in-typescript-of-literal-type-and-string