### PR TITLE
Fix wrong return type for `getEnabledPluginById`

### DIFF
--- a/obsidian-ex.d.ts
+++ b/obsidian-ex.d.ts
@@ -2399,7 +2399,7 @@ declare module "obsidian" {
          */
         getEnabledPluginById<ID extends InternalPluginName>(
             id: ID,
-        ): InternalPlugin<InternalPluginNameInstancesMapping[ID]> | null;
+        ): InternalPluginNameInstancesMapping[ID] | null;
         /**
          * Get all enabled internal plugins
          */


### PR DESCRIPTION
Fixes a copy-paste typo made in #62 