### PR TITLE
[FIX] Extend views improve

### DIFF
--- a/src/obsidian/augmentations/views/MarkdownView.d.ts
+++ b/src/obsidian/augmentations/views/MarkdownView.d.ts
@@ -107,7 +107,7 @@ declare module "obsidian" {
         /**
          * Get the current view type
          */
-        getViewType(): "markdown";
+        getViewType(): string | "markdown";
         /**
          * Validate correctness of frontmatter and update metadata editor
          */

--- a/src/obsidian/internals/Views/AllPropertiesView.d.ts
+++ b/src/obsidian/internals/Views/AllPropertiesView.d.ts
@@ -2,8 +2,8 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class AllPropertiesView extends ItemView {
-	/** @todo Documentation incomplete */
+export interface AllPropertiesView extends ItemView {
+    /** @todo Documentation incomplete */
     startRename(e: unknown): Promise<unknown>;
     /**
      * Called when 'Enter' is pressed while rename. Accepts the rename
@@ -54,6 +54,4 @@ export class AllPropertiesView extends ItemView {
     setSortOrder(order: unknown): void;
     /** @todo Documentation incomplete */
     update(): void;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/AllPropertiesView.d.ts
+++ b/src/obsidian/internals/Views/AllPropertiesView.d.ts
@@ -2,8 +2,8 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface AllPropertiesView extends ItemView {
-    /** @todo Documentation incomplete */
+export class AllPropertiesView extends ItemView {
+	/** @todo Documentation incomplete */
     startRename(e: unknown): Promise<unknown>;
     /**
      * Called when 'Enter' is pressed while rename. Accepts the rename
@@ -54,4 +54,6 @@ export interface AllPropertiesView extends ItemView {
     setSortOrder(order: unknown): void;
     /** @todo Documentation incomplete */
     update(): void;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/AllPropertiesView.d.ts
+++ b/src/obsidian/internals/Views/AllPropertiesView.d.ts
@@ -46,7 +46,7 @@ export interface AllPropertiesView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "all-properties";
+    getViewType(): string | "all-properties";
     /**
      * Updates the sort order and sort by it
      * @param order - The sort order

--- a/src/obsidian/internals/Views/AudioView.d.ts
+++ b/src/obsidian/internals/Views/AudioView.d.ts
@@ -1,7 +1,7 @@
 import type { EditableFileView } from "obsidian";
 
 /** @public */
-export interface AudioView extends EditableFileView {
+export class AudioView extends EditableFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/AudioView.d.ts
+++ b/src/obsidian/internals/Views/AudioView.d.ts
@@ -5,5 +5,5 @@ export interface AudioView extends EditableFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "audio";
+    getViewType(): string | "audio";
 }

--- a/src/obsidian/internals/Views/AudioView.d.ts
+++ b/src/obsidian/internals/Views/AudioView.d.ts
@@ -1,7 +1,7 @@
 import type { EditableFileView } from "obsidian";
 
 /** @public */
-export class AudioView extends EditableFileView {
+export interface AudioView extends EditableFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/BacklinkView.d.ts
+++ b/src/obsidian/internals/Views/BacklinkView.d.ts
@@ -2,7 +2,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface BacklinkView extends InfoFileView {
+export class BacklinkView extends InfoFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/BacklinkView.d.ts
+++ b/src/obsidian/internals/Views/BacklinkView.d.ts
@@ -6,7 +6,7 @@ export interface BacklinkView extends InfoFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "backlink";
+    getViewType(): string | "backlink";
     /**
      * Shows the search
      */

--- a/src/obsidian/internals/Views/BacklinkView.d.ts
+++ b/src/obsidian/internals/Views/BacklinkView.d.ts
@@ -2,7 +2,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class BacklinkView extends InfoFileView {
+export interface BacklinkView extends InfoFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/BookmarksView.d.ts
+++ b/src/obsidian/internals/Views/BookmarksView.d.ts
@@ -5,7 +5,7 @@ import type {
 
 /** @todo Documentation incomplete */
 /** @public */
-export class BookmarksView extends ItemView {
+export interface BookmarksView extends ItemView {
     /**
      * Called when a file is created.
      * @param file - The created file
@@ -60,6 +60,4 @@ export class BookmarksView extends ItemView {
     _copyToClipboard(e: unknown, t: unknown): void;
     /** @todo Documentation incomplete */
     _getActiveBookmarks(): unknown[];
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/BookmarksView.d.ts
+++ b/src/obsidian/internals/Views/BookmarksView.d.ts
@@ -5,7 +5,7 @@ import type {
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface BookmarksView extends ItemView {
+export class BookmarksView extends ItemView {
     /**
      * Called when a file is created.
      * @param file - The created file
@@ -60,4 +60,6 @@ export interface BookmarksView extends ItemView {
     _copyToClipboard(e: unknown, t: unknown): void;
     /** @todo Documentation incomplete */
     _getActiveBookmarks(): unknown[];
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/BookmarksView.d.ts
+++ b/src/obsidian/internals/Views/BookmarksView.d.ts
@@ -21,7 +21,7 @@ export interface BookmarksView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "bookmarks";
+    getViewType(): string | "bookmarks";
     /** @todo Documentation incomplete */
     isItem(item: unknown): boolean;
     /**

--- a/src/obsidian/internals/Views/BrowserHistoryView.d.ts
+++ b/src/obsidian/internals/Views/BrowserHistoryView.d.ts
@@ -2,13 +2,11 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class BrowserHistoryView extends ItemView {
+export interface BrowserHistoryView extends ItemView {
     /**
      * Get the current view type
      */
     getViewType(): string | "browser-history";
     /** @todo Documentation incomplete */
     update(): Promise<unknown>;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/BrowserHistoryView.d.ts
+++ b/src/obsidian/internals/Views/BrowserHistoryView.d.ts
@@ -2,11 +2,13 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface BrowserHistoryView extends ItemView {
+export class BrowserHistoryView extends ItemView {
     /**
      * Get the current view type
      */
     getViewType(): string | "browser-history";
     /** @todo Documentation incomplete */
     update(): Promise<unknown>;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/BrowserHistoryView.d.ts
+++ b/src/obsidian/internals/Views/BrowserHistoryView.d.ts
@@ -6,7 +6,7 @@ export interface BrowserHistoryView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "browser-history";
+    getViewType(): string | "browser-history";
     /** @todo Documentation incomplete */
     update(): Promise<unknown>;
 }

--- a/src/obsidian/internals/Views/BrowserView.d.ts
+++ b/src/obsidian/internals/Views/BrowserView.d.ts
@@ -2,7 +2,7 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class BrowserView extends ItemView {
+export interface BrowserView extends ItemView {
     /**
      * Get the current view type
      */
@@ -101,6 +101,4 @@ export class BrowserView extends ItemView {
     onTagClick(e: unknown, t: unknown, n: unknown): void;
     /** @todo Documentation incomplete */
     onExternalLinkRightClick(e: unknown, t: unknown, n: unknown): void;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/BrowserView.d.ts
+++ b/src/obsidian/internals/Views/BrowserView.d.ts
@@ -2,7 +2,7 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface BrowserView extends ItemView {
+export class BrowserView extends ItemView {
     /**
      * Get the current view type
      */
@@ -101,4 +101,6 @@ export interface BrowserView extends ItemView {
     onTagClick(e: unknown, t: unknown, n: unknown): void;
     /** @todo Documentation incomplete */
     onExternalLinkRightClick(e: unknown, t: unknown, n: unknown): void;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/BrowserView.d.ts
+++ b/src/obsidian/internals/Views/BrowserView.d.ts
@@ -6,7 +6,7 @@ export interface BrowserView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "browser";
+    getViewType(): string | "browser";
     /**
      * Toggles the reader mode
      */

--- a/src/obsidian/internals/Views/CanvasView.d.ts
+++ b/src/obsidian/internals/Views/CanvasView.d.ts
@@ -6,7 +6,7 @@ export interface CanvasView extends TextFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "canvas";
+    getViewType(): string | "canvas";
     /**
      * Loads the local data of the canvas
      */

--- a/src/obsidian/internals/Views/CanvasView.d.ts
+++ b/src/obsidian/internals/Views/CanvasView.d.ts
@@ -2,8 +2,8 @@ import type { TextFileView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface CanvasView extends TextFileView {
-    /**
+export class CanvasView extends TextFileView {
+	/**
      * Get the current view type
      */
     getViewType(): string | "canvas";
@@ -15,4 +15,10 @@ export interface CanvasView extends TextFileView {
      * Saves the local data of the canvas
      */
     saveLocalData(): void;
+	// Documentation allready done just here because of abstaract class implementation
+	getViewData(): string;
+	// Documentation allready done just here because of abstaract class implementation
+	setViewData(data: string, clear: boolean): void;
+	// Documentation allready done just here because of abstaract class implementation
+	clear(): void;
 }

--- a/src/obsidian/internals/Views/CanvasView.d.ts
+++ b/src/obsidian/internals/Views/CanvasView.d.ts
@@ -2,8 +2,8 @@ import type { TextFileView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class CanvasView extends TextFileView {
-	/**
+export interface CanvasView extends TextFileView {
+    /**
      * Get the current view type
      */
     getViewType(): string | "canvas";
@@ -15,10 +15,4 @@ export class CanvasView extends TextFileView {
      * Saves the local data of the canvas
      */
     saveLocalData(): void;
-	// Documentation allready done just here because of abstaract class implementation
-	getViewData(): string;
-	// Documentation allready done just here because of abstaract class implementation
-	setViewData(data: string, clear: boolean): void;
-	// Documentation allready done just here because of abstaract class implementation
-	clear(): void;
 }

--- a/src/obsidian/internals/Views/EmptyView.d.ts
+++ b/src/obsidian/internals/Views/EmptyView.d.ts
@@ -1,11 +1,9 @@
 import type { ItemView } from "obsidian";
 
 /** @public */
-export class EmptyView extends ItemView {
+export interface EmptyView extends ItemView {
     /**
      * Get the current view type
      */
     getViewType(): string | "empty";
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/EmptyView.d.ts
+++ b/src/obsidian/internals/Views/EmptyView.d.ts
@@ -1,9 +1,11 @@
 import type { ItemView } from "obsidian";
 
 /** @public */
-export interface EmptyView extends ItemView {
+export class EmptyView extends ItemView {
     /**
      * Get the current view type
      */
     getViewType(): string | "empty";
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/EmptyView.d.ts
+++ b/src/obsidian/internals/Views/EmptyView.d.ts
@@ -5,5 +5,5 @@ export interface EmptyView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "empty";
+    getViewType(): string | "empty";
 }

--- a/src/obsidian/internals/Views/FileExplorerView.d.ts
+++ b/src/obsidian/internals/Views/FileExplorerView.d.ts
@@ -12,7 +12,7 @@ import type { FileExplorerViewFileItemsRecord } from "./FileExplorerViewFileItem
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface FileExplorerView extends View {
+export class FileExplorerView extends View {
     /**
      * Mapping of file path to tree item
      */
@@ -171,4 +171,6 @@ export interface FileExplorerView extends View {
      * Event: 'extensions-updated'
      */
     onExtensionsUpdated(): void;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/FileExplorerView.d.ts
+++ b/src/obsidian/internals/Views/FileExplorerView.d.ts
@@ -45,7 +45,7 @@ export interface FileExplorerView extends View {
     /**
      * Get the current view type
      */
-    getViewType(): "file-explorer";
+    getViewType(): string | "file-explorer";
     /**
      * Is called when a new file is created in vault. Updates the file tree
      * @param file - The new file

--- a/src/obsidian/internals/Views/FileExplorerView.d.ts
+++ b/src/obsidian/internals/Views/FileExplorerView.d.ts
@@ -12,7 +12,7 @@ import type { FileExplorerViewFileItemsRecord } from "./FileExplorerViewFileItem
 
 /** @todo Documentation incomplete */
 /** @public */
-export class FileExplorerView extends View {
+export interface FileExplorerView extends View {
     /**
      * Mapping of file path to tree item
      */
@@ -171,6 +171,4 @@ export class FileExplorerView extends View {
      * Event: 'extensions-updated'
      */
     onExtensionsUpdated(): void;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/FilePropertiesView.d.ts
+++ b/src/obsidian/internals/Views/FilePropertiesView.d.ts
@@ -31,7 +31,7 @@ export interface FilePropertiesView extends InfoFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "file-properties";
+    getViewType(): string | "file-properties";
     /** @todo Documentation incomplete */
     updateFrontmatter(file: TFile, t: unknown): unknown;
     /** @todo Documentation incomplete */

--- a/src/obsidian/internals/Views/FilePropertiesView.d.ts
+++ b/src/obsidian/internals/Views/FilePropertiesView.d.ts
@@ -3,7 +3,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface FilePropertiesView extends InfoFileView {
+export class FilePropertiesView extends InfoFileView {
     /**
      * Returns the file
      */

--- a/src/obsidian/internals/Views/FilePropertiesView.d.ts
+++ b/src/obsidian/internals/Views/FilePropertiesView.d.ts
@@ -3,7 +3,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class FilePropertiesView extends InfoFileView {
+export interface FilePropertiesView extends InfoFileView {
     /**
      * Returns the file
      */

--- a/src/obsidian/internals/Views/GraphView.d.ts
+++ b/src/obsidian/internals/Views/GraphView.d.ts
@@ -2,7 +2,7 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface GraphView extends ItemView {
+export class GraphView extends ItemView {
     dataEngine: unknown;
     /**
      * Get the current view type
@@ -16,4 +16,6 @@ export interface GraphView extends ItemView {
      * Updates the options from the plugin when changed in view
      */
     onOptionsChange(): void;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/GraphView.d.ts
+++ b/src/obsidian/internals/Views/GraphView.d.ts
@@ -2,7 +2,7 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class GraphView extends ItemView {
+export interface GraphView extends ItemView {
     dataEngine: unknown;
     /**
      * Get the current view type
@@ -16,6 +16,4 @@ export class GraphView extends ItemView {
      * Updates the options from the plugin when changed in view
      */
     onOptionsChange(): void;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/GraphView.d.ts
+++ b/src/obsidian/internals/Views/GraphView.d.ts
@@ -7,7 +7,7 @@ export interface GraphView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "graph";
+    getViewType(): string | "graph";
     /**
      * Renders the graph
      */

--- a/src/obsidian/internals/Views/ImageView.d.ts
+++ b/src/obsidian/internals/Views/ImageView.d.ts
@@ -5,5 +5,5 @@ export interface ImageView extends EditableFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "image";
+    getViewType(): string | "image";
 }

--- a/src/obsidian/internals/Views/ImageView.d.ts
+++ b/src/obsidian/internals/Views/ImageView.d.ts
@@ -1,7 +1,7 @@
 import type { EditableFileView } from "obsidian";
 
 /** @public */
-export class ImageView extends EditableFileView {
+export interface ImageView extends EditableFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/ImageView.d.ts
+++ b/src/obsidian/internals/Views/ImageView.d.ts
@@ -1,7 +1,7 @@
 import type { EditableFileView } from "obsidian";
 
 /** @public */
-export interface ImageView extends EditableFileView {
+export class ImageView extends EditableFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/InfoFileView.d.ts
+++ b/src/obsidian/internals/Views/InfoFileView.d.ts
@@ -7,7 +7,7 @@ import type {
  * @todo This is probably not the right term
  */
 /** @public */
-export interface InfoFileView extends FileView {
+export abstract class InfoFileView extends FileView {
     /**
      * Called when a file is opened. Loads the file and requests a content update
      * @param file - The opened file

--- a/src/obsidian/internals/Views/InfoFileView.d.ts
+++ b/src/obsidian/internals/Views/InfoFileView.d.ts
@@ -7,7 +7,7 @@ import type {
  * @todo This is probably not the right term
  */
 /** @public */
-export abstract class InfoFileView extends FileView {
+export interface InfoFileView extends FileView {
     /**
      * Called when a file is opened. Loads the file and requests a content update
      * @param file - The opened file

--- a/src/obsidian/internals/Views/LocalGraphView.d.ts
+++ b/src/obsidian/internals/Views/LocalGraphView.d.ts
@@ -7,7 +7,7 @@ export interface LocalGraphView extends InfoFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "localgraph";
+    getViewType(): string | "localgraph";
     /**
      * Requests a update if the changed file is the opened file
      * @param file - The changed file

--- a/src/obsidian/internals/Views/LocalGraphView.d.ts
+++ b/src/obsidian/internals/Views/LocalGraphView.d.ts
@@ -3,7 +3,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class LocalGraphView extends InfoFileView {
+export interface LocalGraphView extends InfoFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/LocalGraphView.d.ts
+++ b/src/obsidian/internals/Views/LocalGraphView.d.ts
@@ -3,7 +3,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface LocalGraphView extends InfoFileView {
+export class LocalGraphView extends InfoFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/OutgoingLinkView.d.ts
+++ b/src/obsidian/internals/Views/OutgoingLinkView.d.ts
@@ -2,7 +2,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface OutgoingLinkView extends InfoFileView {
+export class OutgoingLinkView extends InfoFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/OutgoingLinkView.d.ts
+++ b/src/obsidian/internals/Views/OutgoingLinkView.d.ts
@@ -2,7 +2,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class OutgoingLinkView extends InfoFileView {
+export interface OutgoingLinkView extends InfoFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/OutgoingLinkView.d.ts
+++ b/src/obsidian/internals/Views/OutgoingLinkView.d.ts
@@ -6,7 +6,7 @@ export interface OutgoingLinkView extends InfoFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "outgoing-link";
+    getViewType(): string | "outgoing-link";
     /** @todo Documentation incomplete */
     update(): void;
 }

--- a/src/obsidian/internals/Views/OutlineView.d.ts
+++ b/src/obsidian/internals/Views/OutlineView.d.ts
@@ -7,7 +7,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface OutlineView extends InfoFileView {
+export class OutlineView extends InfoFileView {
     /**
      * Finds the active leaf
      */

--- a/src/obsidian/internals/Views/OutlineView.d.ts
+++ b/src/obsidian/internals/Views/OutlineView.d.ts
@@ -7,7 +7,7 @@ import type { InfoFileView } from "./InfoFileView.js";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class OutlineView extends InfoFileView {
+export interface OutlineView extends InfoFileView {
     /**
      * Finds the active leaf
      */

--- a/src/obsidian/internals/Views/OutlineView.d.ts
+++ b/src/obsidian/internals/Views/OutlineView.d.ts
@@ -17,7 +17,7 @@ export interface OutlineView extends InfoFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "outline";
+    getViewType(): string | "outline";
     /** @todo Documentation incomplete */
     findActiveHeading(e: unknown): unknown | undefined;
     /** @todo Documentation incomplete */

--- a/src/obsidian/internals/Views/PdfView.d.ts
+++ b/src/obsidian/internals/Views/PdfView.d.ts
@@ -11,7 +11,7 @@ export interface PdfView extends EditableFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "pdf";
+    getViewType(): string | "pdf";
     /**
      * Is called when the vault has a "modify" event. Reloads the file if the modified file is the file in this view.
      * @param file - The modified file

--- a/src/obsidian/internals/Views/PdfView.d.ts
+++ b/src/obsidian/internals/Views/PdfView.d.ts
@@ -5,7 +5,7 @@ import type {
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface PdfView extends EditableFileView {
+export class PdfView extends EditableFileView {
     viewer: unknown;
 
     /**

--- a/src/obsidian/internals/Views/PdfView.d.ts
+++ b/src/obsidian/internals/Views/PdfView.d.ts
@@ -5,7 +5,7 @@ import type {
 
 /** @todo Documentation incomplete */
 /** @public */
-export class PdfView extends EditableFileView {
+export interface PdfView extends EditableFileView {
     viewer: unknown;
 
     /**

--- a/src/obsidian/internals/Views/ReleaseNotesView.d.ts
+++ b/src/obsidian/internals/Views/ReleaseNotesView.d.ts
@@ -2,7 +2,7 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface ReleaseNotesView extends ItemView {
+export class ReleaseNotesView extends ItemView {
     /**
      * Get the current view type
      */
@@ -18,4 +18,6 @@ export interface ReleaseNotesView extends ItemView {
      * Renders the release notes
      */
     render(): Promise<unknown>;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/ReleaseNotesView.d.ts
+++ b/src/obsidian/internals/Views/ReleaseNotesView.d.ts
@@ -6,7 +6,7 @@ export interface ReleaseNotesView extends ItemView {
     /**
      * Get the current view type
      */
-    getViewType(): "release-notes";
+    getViewType(): string | "release-notes";
     /**
      * Get the release notes from GitHub
      * @param version - The version of the release notes

--- a/src/obsidian/internals/Views/ReleaseNotesView.d.ts
+++ b/src/obsidian/internals/Views/ReleaseNotesView.d.ts
@@ -2,7 +2,7 @@ import type { ItemView } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class ReleaseNotesView extends ItemView {
+export interface ReleaseNotesView extends ItemView {
     /**
      * Get the current view type
      */
@@ -18,6 +18,4 @@ export class ReleaseNotesView extends ItemView {
      * Renders the release notes
      */
     render(): Promise<unknown>;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/SearchView.d.ts
+++ b/src/obsidian/internals/Views/SearchView.d.ts
@@ -2,7 +2,7 @@ import type { View } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class SearchView extends View {
+export interface SearchView extends View {
     /** @todo Documentation incomplete */
     onCopyResultsClick(event: MouseEvent): void;
     /** @todo Documentation incomplete */
@@ -64,6 +64,4 @@ export class SearchView extends View {
      * Called when the tap header is clicked. Brings this tab to the front
      */
     onTabHeaderClick(): void;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/SearchView.d.ts
+++ b/src/obsidian/internals/Views/SearchView.d.ts
@@ -32,7 +32,7 @@ export interface SearchView extends View {
     /**
      * Get the current view type
      */
-    getViewType(): "search";
+    getViewType(): string | "search";
     /** @todo Documentation incomplete */
     onKeyArrowRightInFocus(event: KeyboardEvent): void;
     /** @todo Documentation incomplete */

--- a/src/obsidian/internals/Views/SearchView.d.ts
+++ b/src/obsidian/internals/Views/SearchView.d.ts
@@ -2,7 +2,7 @@ import type { View } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface SearchView extends View {
+export class SearchView extends View {
     /** @todo Documentation incomplete */
     onCopyResultsClick(event: MouseEvent): void;
     /** @todo Documentation incomplete */
@@ -64,4 +64,6 @@ export interface SearchView extends View {
      * Called when the tap header is clicked. Brings this tab to the front
      */
     onTabHeaderClick(): void;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/TagView.d.ts
+++ b/src/obsidian/internals/Views/TagView.d.ts
@@ -12,7 +12,7 @@ export interface TagView extends View {
     /**
      * Get the current view type
      */
-    getViewType(): "tag";
+    getViewType(): string | "tag";
     /** @todo Documentation incomplete */
     setIsAllCollapsed(e: unknown): void;
     /** @todo Documentation incomplete */

--- a/src/obsidian/internals/Views/TagView.d.ts
+++ b/src/obsidian/internals/Views/TagView.d.ts
@@ -2,7 +2,7 @@ import type { View } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export interface TagView extends View {
+export class TagView extends View {
     /** @todo Documentation incomplete */
     getNodeId(e: unknown): unknown;
     /** @todo Documentation incomplete */
@@ -21,4 +21,6 @@ export interface TagView extends View {
      * Reloads all tags from vault, update all items and sort those
      */
     updateTags(): void;
+	/** @todo Documentation incomplete */
+	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/TagView.d.ts
+++ b/src/obsidian/internals/Views/TagView.d.ts
@@ -2,7 +2,7 @@ import type { View } from "obsidian";
 
 /** @todo Documentation incomplete */
 /** @public */
-export class TagView extends View {
+export interface TagView extends View {
     /** @todo Documentation incomplete */
     getNodeId(e: unknown): unknown;
     /** @todo Documentation incomplete */
@@ -21,6 +21,4 @@ export class TagView extends View {
      * Reloads all tags from vault, update all items and sort those
      */
     updateTags(): void;
-	/** @todo Documentation incomplete */
-	getDisplayText(): string;
 }

--- a/src/obsidian/internals/Views/UnknownView.d.ts
+++ b/src/obsidian/internals/Views/UnknownView.d.ts
@@ -5,4 +5,4 @@ import type { EmptyView } from "./EmptyView.js";
  * @todo This is probably not the right term
  */
 /** @public */
-export interface UnknownView extends EmptyView {}
+export class UnknownView extends EmptyView {}

--- a/src/obsidian/internals/Views/UnknownView.d.ts
+++ b/src/obsidian/internals/Views/UnknownView.d.ts
@@ -5,4 +5,4 @@ import type { EmptyView } from "./EmptyView.js";
  * @todo This is probably not the right term
  */
 /** @public */
-export class UnknownView extends EmptyView {}
+export interface UnknownView extends EmptyView {}

--- a/src/obsidian/internals/Views/VideoView.d.ts
+++ b/src/obsidian/internals/Views/VideoView.d.ts
@@ -5,5 +5,5 @@ export interface VideoView extends EditableFileView {
     /**
      * Get the current view type
      */
-    getViewType(): "video";
+    getViewType(): string | "video";
 }

--- a/src/obsidian/internals/Views/VideoView.d.ts
+++ b/src/obsidian/internals/Views/VideoView.d.ts
@@ -1,7 +1,7 @@
 import type { EditableFileView } from "obsidian";
 
 /** @public */
-export class VideoView extends EditableFileView {
+export interface VideoView extends EditableFileView {
     /**
      * Get the current view type
      */

--- a/src/obsidian/internals/Views/VideoView.d.ts
+++ b/src/obsidian/internals/Views/VideoView.d.ts
@@ -1,7 +1,7 @@
 import type { EditableFileView } from "obsidian";
 
 /** @public */
-export interface VideoView extends EditableFileView {
+export class VideoView extends EditableFileView {
     /**
      * Get the current view type
      */


### PR DESCRIPTION
As mentioned here https://github.com/Fevol/obsidian-typings/pull/80#issuecomment-2268491508 There are some issues with the latest update.

## Changes
- I updated the return types of the Views to not only return the expected fix string like ``"markdown"`` to also return ``string`` to fix the overriding issue
- I updated the ``interface`` to ``class`` for the internal views so it is possible to use the ``extends`` keyword on them