### PR TITLE
`getLinkSuggestions()` sometimes has `alias` property

### DIFF
--- a/src/obsidian/augmentations/MetadataCache.d.ts
+++ b/src/obsidian/augmentations/MetadataCache.d.ts
@@ -89,7 +89,7 @@ declare module 'obsidian' {
         /**
          * Get all links (resolved or unresolved) in the vault
          */
-        getLinkSuggestions(): { file: TFile | null; path: string }[];
+        getLinkSuggestions(): { file: TFile | null; path: string; alias?: string }[];
         /**
          * Get all tags within the vault and their usage count
          */


### PR DESCRIPTION
It _never_ seems to be an array, despite the metadata editor enforcing the type of value to be an array. It always seems to be the first alias (if any) that's present.