### PR TITLE
Add engine and renderer to views

### DIFF
--- a/src/obsidian/internals/InternalPlugins/Graph/GraphView.d.ts
+++ b/src/obsidian/internals/InternalPlugins/Graph/GraphView.d.ts
@@ -1,10 +1,13 @@
 import type { ItemView } from 'obsidian';
 import type { ViewType } from '../../../implementations/Constants/ViewType.js';
+import type { GraphEngine } from './GraphEngine.js';
+import type { GraphRenderer } from './GraphRenderer.js';
 
 /** @todo Documentation incomplete */
 /** @public */
 export interface GraphView extends ItemView {
-    dataEngine: unknown;
+    dataEngine: GraphEngine;
+    renderer: GraphRenderer;
 
     /**
      * Get the current view type

--- a/src/obsidian/internals/InternalPlugins/Graph/LocalGraphView.d.ts
+++ b/src/obsidian/internals/InternalPlugins/Graph/LocalGraphView.d.ts
@@ -1,10 +1,15 @@
 import type { TFile } from 'obsidian';
 import type { ViewType } from '../../../implementations/Constants/ViewType.js';
 import type { InfoFileView } from '../../Views/InfoFileView.js';
+import type { GraphEngine } from './GraphEngine.js';
+import type { GraphRenderer } from './GraphRenderer.js';
 
 /** @todo Documentation incomplete */
 /** @public */
 export interface LocalGraphView extends InfoFileView {
+    engine: GraphEngine;
+    renderer: GraphRenderer;
+    
     /**
      * Get the current view type
      */


### PR DESCRIPTION
Hi! These are the changes requested [after merging the previous PR](https://github.com/Fevol/obsidian-typings/pull/103#issuecomment-2585536426).

They go like this:

```ts
/* internal/IntenalPlugins/Graph/GraphView.d.ts */
export interface GraphView extends ItemView {
    dataEngine: GraphEngine;
    renderer: GraphRenderer;
}

/* internal/IntenalPlugins/Graph/LocalGraphView.d.ts */
export interface GraphView extends ItemView {
    engine: GraphEngine;
    renderer: GraphRenderer;
}
```

By adding this, the `GraphEngine` will be referenced (by `engine` or `dataEngine`), and it contains instances of classes inheriting `GraphOptions` (`GraphColorGroupOptions`, `GraphDisplayOptions`, `GraphFilterOptions`, `GraphForceOptions`).
As for the `GraphRenderer`, it will be referenced through the property `renderer`, which contains arrays of `GraphLink` and `GraphNode`.

I hope I got it all correctly this time!