### PR TITLE
Add new typings to the graph core plugin

### DIFF
--- a/src/obsidian/internals/InternalPlugins/Graph/GraphEngine.d.ts
+++ b/src/obsidian/internals/InternalPlugins/Graph/GraphEngine.d.ts
@@ -1,5 +1,4 @@
 import type { App } from 'obsidian';
-import type { Renderer } from 'pixi.js';
 import type { GraphColorGroup } from './GraphColorGroup.js';
 import type { GraphPluginInstanceOptions } from './GraphPluginInstanceOptions.js';
 import type { GraphView } from './GraphView.js';
@@ -8,6 +7,7 @@ import type { GraphColorGroupOptions } from './Options/GraphColorGroupOptions.js
 import type { GraphDisplayOptions } from './Options/GraphDisplayOptions.js';
 import type { GraphFilterOptions } from './Options/GraphFilterOptions.js';
 import type { GraphForceOptions } from './Options/GraphForceOptions.js';
+import type { GraphRenderer } from './GraphRenderer.js';
 
 /** @public */
 export interface GraphEngine {
@@ -40,7 +40,7 @@ export interface GraphEngine {
     /** @internal */
     progressionSpeed: number;
     /** @internal */
-    renderer: Renderer;
+    renderer: GraphRenderer;
     /** @internal */
     searchQueries: GraphColorGroup[];
     /** @internal */

--- a/src/obsidian/internals/InternalPlugins/Graph/GraphLink.d.ts
+++ b/src/obsidian/internals/InternalPlugins/Graph/GraphLink.d.ts
@@ -8,11 +8,11 @@ import type { GraphRenderer } from './GraphRenderer.js';
 /** @public */
 export interface GraphLink {
     /** @internal */
-    arrow: Graphics;
+    arrow: Graphics | null;
     /** @internal */
-    line: Graphics;
+    line: Graphics | null;
     /** @internal */
-    px: Container;
+    px: Container | null;
     /** @internal */
     rendered: boolean;
     /** @internal */

--- a/src/obsidian/internals/InternalPlugins/Graph/GraphNode.d.ts
+++ b/src/obsidian/internals/InternalPlugins/Graph/GraphNode.d.ts
@@ -8,11 +8,17 @@ import type { GraphRenderer } from './GraphRenderer.js';
 /** @public */
 export interface GraphNode {
     /** @internal */
-    circle: Graphics;
+    circle: Graphics | null;
     /** @internal */
     color: GraphColorAttributes;
     /** @internal */
     forward: Record<string, GraphNode>;
+	/** @internal */
+	fx: number | null;
+	/** @internal */
+	fy: number | null;
+	/** @internal */
+	highlight: Graphics | null;
     /** @internal */
     id: string;
     /** @internal */
@@ -22,7 +28,7 @@ export interface GraphNode {
     /** @internal */
     reverse: Record<string, GraphNode>;
     /** @internal */
-    text: Text;
+    text: Text | null;
     /** @internal */
     type: string;
     /** @internal */

--- a/src/obsidian/internals/InternalPlugins/Graph/GraphRenderer.d.ts
+++ b/src/obsidian/internals/InternalPlugins/Graph/GraphRenderer.d.ts
@@ -1,4 +1,4 @@
-import { Application } from 'pixi.js';
+import { Application, Container } from 'pixi.js';
 import type { GraphColor } from './GraphColor.js';
 import type { GraphColorAttributes } from './GraphColorAttributes.js';
 import type { GraphLink } from './GraphLink.js';
@@ -8,8 +8,16 @@ import type { GraphNode } from './GraphNode.js';
 export interface GraphRenderer {
     /** @internal */
     colors: Record<GraphColor, GraphColorAttributes>;
+	/** @internal */
+	dragNode: GraphNode | null;
+	/** @internal */
+	fLineSizeMult: number;
     /** @internal */
     fNodeSizeMult: number;
+	/** @internal */
+	hanger: Container;
+	/** @internal */
+	height: number;
     /** @internal */
     idleFrames: number;
     /** @internal */
@@ -30,11 +38,27 @@ export interface GraphRenderer {
     scale: number;
     /** @internal */
     targetScale: number;
+	/** @internal */
+	viewport: {bottom: number, left: number, right: number, top: number};
+	/** @internal */
+	width: number;
     /** @internal */
     worker: Worker;
+	/** @internal */
+	zoomCenterX: number;
+	/** @internal */
+	zoomCenterY: number;
 
     /**
      * Specify that the renderer has changed and needs to be rendered again
      */
     changed(): unknown;
+	/** @internal */
+	renderCallback(): void;
+	/** @internal */
+	getHighlightNode(): GraphNode;
+	/** @internal */
+	setPan(panX: number, panY: number): void;
+	/** @internal */
+	setScale(scale: number): void;
 }


### PR DESCRIPTION
I discovered more attributes and functions that I needed to work with in my plugin, so I added them to the typings.

Also, I changed the type of GraphEngine::renderer to use the GraphRenderer of the core plugin and not the Renderer of pixi.js. I think I made an error the first time and validated the auto-completion too soon. It's fixed now!