### PR TITLE
A few improvements to filesystem-related APIs

### DIFF
--- a/src/obsidian/augmentations/DataAdapter.d.ts
+++ b/src/obsidian/augmentations/DataAdapter.d.ts
@@ -50,7 +50,7 @@ declare module 'obsidian' {
          * @param normalizedPath Path to directory
          * @internal Helper function for `listRecursive` reads children of directory
          */
-        listRecursiveChild(normalizedPath: string): Promise<void>;
+        listRecursiveChild(normalizedPath: string, child: string): Promise<void>;
         /** @internal */
         onFileChange(normalizedPath: string): void;
         /** @internal */
@@ -58,7 +58,11 @@ declare module 'obsidian' {
         /** @internal */
         reconcileFile(normalizedPath: string, normalizedNewPath: string, option: boolean): Promise<void>;
         /** @internal */
-        reconcileFileCreation(normalizedPath: string, normalizedNewPath: string, option: boolean): Promise<void>;
+        reconcileFileCreation(normalizedPath: string, normalizedNewPath: string, option: {
+            birthtimeMs: number;
+            mtimeMs: number;
+            size: number;
+        }): Promise<void>;
         /** @internal */
         reconcileFolderCreation(normalizedPath: string, normalizedNewPath: string): Promise<void>;
         /** @internal */

--- a/src/obsidian/augmentations/FileSystemAdapter.d.ts
+++ b/src/obsidian/augmentations/FileSystemAdapter.d.ts
@@ -55,7 +55,7 @@ declare module 'obsidian' {
         /** @internal Kill file system action due to timeout */
         kill(): void;
         /** @internal */
-        killLastAction(): void;
+        killLastAction: null | ((e: Error)=> void);
         /** @internal Generates `this.files` from the file system */
         listAll(): Promise<void>;
         /** @internal */

--- a/src/obsidian/augmentations/MetadataCache.d.ts
+++ b/src/obsidian/augmentations/MetadataCache.d.ts
@@ -17,6 +17,8 @@ declare module 'obsidian' {
          * Reference to App
          */
         app: App;
+        /** @internal Called by preload() which is in turn called by initialize() */
+        _preload: () => Promise<unknown>;
         /** @internal */
         blockCache: BlockCache;
         /** @internal IndexedDB database */
@@ -60,6 +62,8 @@ declare module 'obsidian' {
         clear(): Promise<void>;
         /** @internal */
         computeMetadataAsync(arrayBuffer: ArrayBuffer): Promise<CachedMetadata | undefined>;
+        /** @internal Called by initialize() */
+        computeFileMetadataAsync(file: TFile): Promise<unknown>;
         /** @internal Remove all entries that contain deleted path */
         deletePath(path: string): void;
         /**

--- a/src/obsidian/augmentations/Reference.d.ts
+++ b/src/obsidian/augmentations/Reference.d.ts
@@ -1,5 +1,8 @@
 export {};
 
 declare module 'obsidian' {
-    interface Reference {}
+    interface Reference {
+        /** @internal dot delimetered, e.g., `symlink.0`, path in the frontmatter to the reference */
+        key?: string;
+    }
 }

--- a/src/obsidian/internals/CapacitorAdapterFs.d.ts
+++ b/src/obsidian/internals/CapacitorAdapterFs.d.ts
@@ -1,5 +1,7 @@
 import type { FileEntry } from './FileEntry.d.ts';
 
+type CapacitorFileEntry = Omit<FileEntry, "type" | "realpath"> & { realpath?: string; type: "file" | "directory"};
+
 /** @public */
 export interface CapacitorAdapterFs {
     dir: string | null;
@@ -16,15 +18,15 @@ export interface CapacitorAdapterFs {
     open(realPath: string): Promise<void>;
     read(realPath: string): Promise<string>;
     readBinary(realPath: string): Promise<ArrayBuffer>;
-    readdir(realPath: string): FileEntry[];
+    readdir(realPath: string): Promise<CapacitorFileEntry[]>;
     rename(realPath: string, newRealPath: string): Promise<void>;
     rmdir(realPath: string): Promise<void>;
     setTimes(realPath: string, ctime: number, mtime: number): Promise<void>;
-    stat(realPath: string): Promise<FileEntry>;
+    stat(realPath: string): Promise<CapacitorFileEntry>;
     trash(realPath: string): Promise<void>;
     verifyIcloud(realPath: string): Promise<void>;
     watch(realPath: string): Promise<void>;
-    watchAndStatAll(realPath: string): Promise<{ children: FileEntry[] }>;
+    watchAndStatAll(realPath: string): Promise<{ children: CapacitorFileEntry[] }>;
     write(realPath: string, data: string): Promise<void>;
     writeBinary(realPath: string, data: ArrayBuffer): Promise<void>;
     writeBinaryInternal(realPath: string, data: ArrayBuffer): Promise<void>;

--- a/src/obsidian/internals/TreeNode.d.ts
+++ b/src/obsidian/internals/TreeNode.d.ts
@@ -18,6 +18,7 @@ export type TreeNode<T = object> = T & {
     };
     pusherEl: HTMLElement;
     vChildren: {
+        addChild: (item: TreeNode<T>) => void;
         _children: TreeNode<T>[];
         owner: TreeNode<T>;
     };


### PR DESCRIPTION
I have been working on a few plugins that dig deep into file loading mechanisms. Here are some improvements that I would like to upstream. I really wish Obsidian was opensource! But for now we have to stick to obsidian-typings, reverse-engineering and monkey-patching... Thank god they do not obfuscate the code extensively...

P.S. I know it is a bit unethical (AI part, not reverse-engineering), but one can just use an LLM to make whole classes perfectly readable within dozens of seconds... And I think it can be easily scaled up 🫣 I am a bit lazy at the moment to edit `CONTRIBUTING.md`, but it seems like a good advice to have there.

P.P.S. Now I see that there actually is a single sentence about LLMs :) I was confused by async state machines descriptions as they feel somewhat redundant once you get used to LLMs, though I do like to get my hands dirty at times too 😉