### PR TITLE
feat: improve EmbedRegistryEmbedByExtensionRecord type

### DIFF
--- a/src/obsidian/internals/EmbedRegistry/EmbedRegistryEmbedByExtensionRecord.d.ts
+++ b/src/obsidian/internals/EmbedRegistry/EmbedRegistryEmbedByExtensionRecord.d.ts
@@ -1,4 +1,4 @@
 import type { EmbeddableConstructor } from '../EmbeddableConstructor.d.ts';
 
 /** @public */
-export interface EmbedRegistryEmbedByExtensionRecord extends Record<string, EmbeddableConstructor> {}
+export interface EmbedRegistryEmbedByExtensionRecord extends Record<"md", EmbeddableConstructor>, Record<string, EmbeddableConstructor> {}


### PR DESCRIPTION
This embed is always present during a plugin's onload() phase, so it would be nice to change the type to something that does not trigger `noPropertyAccessFromIndexSignature` needlessly 