### PR TITLE
Various `MetadataTypeManager` related updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12046,6 +12046,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-preprocess": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-6.0.3.tgz",

--- a/src/obsidian/internals/MetadataTypeManager/MetadataTypeManager.d.ts
+++ b/src/obsidian/internals/MetadataTypeManager/MetadataTypeManager.d.ts
@@ -1,15 +1,9 @@
-import type {
-    App,
-    Debouncer,
-    Events
-} from 'obsidian';
+import type { App, Debouncer, Events } from 'obsidian';
 import type { PropertyInfo } from '../PropertyInfo.d.ts';
 import type { PropertyWidgetType } from '../PropertyWidgetType.d.ts';
 import type { GetTypeInfoOptions } from './GetTypeInfoOptions.d.ts';
 import type { MetadataTypeManagerPropertiesRecord } from './MetadataTypeManagerPropertiesRecord.d.ts';
-import type {
-    MetadataTypeManagerRegisteredTypeWidgetsRecord
-} from './MetadataTypeManagerRegisteredTypeWidgetsRecord.d.ts';
+import type { MetadataTypeManagerRegisteredTypeWidgetsRecord } from './MetadataTypeManagerRegisteredTypeWidgetsRecord.d.ts';
 import type { MetadataTypeManagerTypesRecord } from './MetadataTypeManagerTypesRecord.d.ts';
 import type { TypeInfo } from './TypeInfo.d.ts';
 
@@ -23,6 +17,16 @@ export interface MetadataTypeManager extends Events {
      * Reference to App.
      */
     app: App;
+
+    /**
+     * Associated widget types for each property.
+     */
+    assignedWidgets: MetadataTypeManagerTypesRecord;
+
+    /**
+     * Unix timestamp of the last save
+     */
+    lastSave: number;
 
     /** @todo Documentation incomplete. */
     onConfigFileChange: Debouncer<[], Promise<void>>;
@@ -38,11 +42,6 @@ export interface MetadataTypeManager extends Events {
     registeredTypeWidgets: MetadataTypeManagerRegisteredTypeWidgetsRecord;
 
     /**
-     * Associated widget types for each property.
-     */
-    types: MetadataTypeManagerTypesRecord;
-
-    /**
      * Get all registered properties of the vault.
      */
     getAllProperties(): Record<string, PropertyInfo>;
@@ -50,7 +49,7 @@ export interface MetadataTypeManager extends Events {
     /**
      * Get assigned widget type for property.
      */
-    getAssignedType(property: string): PropertyWidgetType | null;
+    getAssignedWidget(property: string): PropertyWidgetType | null;
 
     /**
      * Get info for property.
@@ -61,11 +60,6 @@ export interface MetadataTypeManager extends Events {
      * Get expected widget type for property and the one inferred from the property value.
      */
     getTypeInfo(options: GetTypeInfoOptions): TypeInfo;
-
-    /**
-     * Get all properties with an assigned widget type.
-     */
-    getTypes(): string[];
 
     /**
      * Load property types from config.
@@ -84,11 +78,6 @@ export interface MetadataTypeManager extends Events {
     save(): Promise<void>;
 
     /**
-     * Get all properties from metadata cache.
-     */
-    savePropertyInfo(): void;
-
-    /**
      * Set widget type for property.
      */
     setType(property: string, type: PropertyWidgetType): Promise<void>;
@@ -97,4 +86,9 @@ export interface MetadataTypeManager extends Events {
      * Unset widget type for property.
      */
     unsetType(property: string): Promise<void>;
+
+    /**
+     * Updates `this.properties` to match the MetadataCache
+     */
+    updatePropertyInfoCache(): void;
 }

--- a/src/obsidian/internals/MetadataTypeManager/MetadataTypeManagerRegisteredTypeWidgetsRecord.d.ts
+++ b/src/obsidian/internals/MetadataTypeManager/MetadataTypeManagerRegisteredTypeWidgetsRecord.d.ts
@@ -8,6 +8,7 @@ import type { FilePropertyWidgetComponent } from './FilePropertyWidgetComponent.
 import type { FolderPropertyWidgetComponent } from './FolderPropertyWidgetComponent.d.ts';
 import type { MultitextPropertyWidgetComponent } from './MultitextPropertyWidgetComponent.d.ts';
 import type { NumberPropertyWidgetComponent } from './NumberPropertyWidgetComponent.d.ts';
+import type { PropertyPropertyWidgetComponent } from './PropertyPropertyWidgetComponent.js';
 import type { TagsPropertyWidgetComponent } from './TagsPropertyWidgetComponent.d.ts';
 import type { TextPropertyWidgetComponent } from './TextPropertyWidgetComponent.d.ts';
 
@@ -46,7 +47,7 @@ export interface MetadataTypeManagerRegisteredTypeWidgetsRecord
     number: PropertyWidget<number, NumberPropertyWidgetComponent>;
 
     /** @todo Documentation incomplete. */
-    property: PropertyWidget<number, NumberPropertyWidgetComponent>;
+    property: PropertyWidget<string, PropertyPropertyWidgetComponent>;
 
     /** @todo Documentation incomplete. */
     tags: PropertyWidget<string[], TagsPropertyWidgetComponent>;

--- a/src/obsidian/internals/MetadataTypeManager/MetadataTypeManagerRegisteredTypeWidgetsRecord.d.ts
+++ b/src/obsidian/internals/MetadataTypeManager/MetadataTypeManagerRegisteredTypeWidgetsRecord.d.ts
@@ -17,8 +17,7 @@ import type { TextPropertyWidgetComponent } from './TextPropertyWidgetComponent.
  * @unofficial
  */
 export interface MetadataTypeManagerRegisteredTypeWidgetsRecord
-    extends Record<PropertyWidgetType, PropertyWidget<unknown>>
-{
+    extends Record<PropertyWidgetType, PropertyWidget<unknown>> {
     /** @todo Documentation incomplete. */
     aliases: PropertyWidget<string | string[], AliasesPropertyWidgetComponent>;
 
@@ -29,7 +28,10 @@ export interface MetadataTypeManagerRegisteredTypeWidgetsRecord
     date: PropertyWidget<moment.MomentInput, DatePropertyWidgetComponent>;
 
     /** @todo Documentation incomplete. */
-    datetime: PropertyWidget<moment.MomentInput, DatetimePropertyWidgetComponent>;
+    datetime: PropertyWidget<
+        moment.MomentInput,
+        DatetimePropertyWidgetComponent
+    >;
 
     /** @todo Documentation incomplete. */
     file: PropertyWidget<string, FilePropertyWidgetComponent>;
@@ -42,6 +44,9 @@ export interface MetadataTypeManagerRegisteredTypeWidgetsRecord
 
     /** @todo Documentation incomplete. */
     number: PropertyWidget<number, NumberPropertyWidgetComponent>;
+
+    /** @todo Documentation incomplete. */
+    property: PropertyWidget<number, NumberPropertyWidgetComponent>;
 
     /** @todo Documentation incomplete. */
     tags: PropertyWidget<string[], TagsPropertyWidgetComponent>;

--- a/src/obsidian/internals/MetadataTypeManager/PropertyPropertyWidgetComponent.d.ts
+++ b/src/obsidian/internals/MetadataTypeManager/PropertyPropertyWidgetComponent.d.ts
@@ -1,0 +1,18 @@
+import type { PropertyWidgetComponentBase } from './PropertyWidgetComponentBase.d.ts';
+
+/**
+ * @todo Documentation incomplete.
+ * @public
+ * @unofficial
+ */
+export interface PropertyPropertyWidgetComponent
+    extends PropertyWidgetComponentBase {
+    /** @todo Documentation incomplete. */
+    inputEl: HTMLInputElement;
+
+    /** @todo Documentation incomplete. */
+    type: 'property';
+
+    /** @todo Documentation incomplete. */
+    setValue(value: string | null): void;
+}

--- a/src/obsidian/internals/MetadataTypeManager/PropertyWidgetComponentBase.d.ts
+++ b/src/obsidian/internals/MetadataTypeManager/PropertyWidgetComponentBase.d.ts
@@ -6,7 +6,7 @@ import type { FocusMode } from '../FocusMode.d.ts';
  * @public
  * @unofficial
  */
-export interface PropertyWidgetComponentBase extends Component {
+export interface PropertyWidgetComponentBase {
     /** @todo Documentation incomplete. */
     containerEl: HTMLElement;
 

--- a/src/obsidian/internals/MetadataTypeManager/PropertyWidgetComponentBase.d.ts
+++ b/src/obsidian/internals/MetadataTypeManager/PropertyWidgetComponentBase.d.ts
@@ -1,4 +1,3 @@
-import type { Component } from 'obsidian';
 import type { FocusMode } from '../FocusMode.d.ts';
 
 /**

--- a/src/obsidian/internals/PropertyInfo.d.ts
+++ b/src/obsidian/internals/PropertyInfo.d.ts
@@ -7,7 +7,7 @@ export interface PropertyInfo {
     /**
      * Usage count of property.
      */
-    count: number;
+    occurrences: number;
 
     /**
      * Name of property.
@@ -17,5 +17,5 @@ export interface PropertyInfo {
     /**
      * Type of property.
      */
-    type: string;
+    widget: string;
 }

--- a/src/obsidian/internals/PropertyRenderContext.d.ts
+++ b/src/obsidian/internals/PropertyRenderContext.d.ts
@@ -18,11 +18,6 @@ export interface PropertyRenderContext {
     key: string;
 
     /**
-     * Reference to the metadata editor.
-     */
-    metadataEditor: MetadataEditor;
-
-    /**
      * Determine the source path of current context.
      */
     sourcePath: string;

--- a/src/obsidian/internals/PropertyWidget.d.ts
+++ b/src/obsidian/internals/PropertyWidget.d.ts
@@ -1,13 +1,17 @@
 import type { Component } from 'obsidian';
 import type { PropertyEntryData } from './PropertyEntryData.d.ts';
 import type { PropertyRenderContext } from './PropertyRenderContext.d.ts';
+import type { PropertyWidgetComponentBase } from './MetadataTypeManager/PropertyWidgetComponentBase.js';
 
 /**
  * @todo Documentation incomplete.
  * @public
  * @unofficial
  */
-export interface PropertyWidget<Value = unknown, ComponentType extends Component = Component> {
+export interface PropertyWidget<
+    Value = unknown,
+    ComponentType extends PropertyWidgetComponentBase = PropertyWidgetComponentBase
+> {
     /**
      * Lucide-dev icon associated with the widget.
      */
@@ -31,7 +35,11 @@ export interface PropertyWidget<Value = unknown, ComponentType extends Component
     /**
      * Render function for the widget on field container given context and data.
      */
-    render(containerEl: HTMLElement, data: Value, context: PropertyRenderContext): ComponentType;
+    render(
+        containerEl: HTMLElement,
+        data: Value,
+        context: PropertyRenderContext
+    ): ComponentType;
 
     /**
      * Validate whether the input value to the widget is correct.

--- a/src/obsidian/internals/PropertyWidgetEntry.d.ts
+++ b/src/obsidian/internals/PropertyWidgetEntry.d.ts
@@ -10,5 +10,5 @@ export interface PropertyWidgetEntry {
     name: string;
 
     /** @todo Documentation incomplete. */
-    type: PropertyWidgetType;
+    widget: PropertyWidgetType;
 }


### PR DESCRIPTION
- `MetadataTypeManager` various methods and properties were renamed or removed
- Added `MetadataTypeManagerRegisteredTypeWidgetsRecord.property` and created `PropertyPropertyWidgetComponent` accordingly
- PropertyComponentBase does not extend Component